### PR TITLE
Fix bugs that occur when downloading wget

### DIFF
--- a/src/fosslight_scanner_service/config.py
+++ b/src/fosslight_scanner_service/config.py
@@ -26,6 +26,8 @@ class Config(object):
 
     CELERY_BROKER_URL = 'redis://127.0.0.1:6379'
     CELERY_RESULT_BACKEND = 'redis://127.0.0.1:6379'
+    CELERY_REDIRECT_STDOUTS = False
+    worker_redirect_stdouts = False
 
     FL_HUB_TOKEN = "eyJhABCD***"
     FL_HUB_REGISTER_URL = "https://demo.fosslight.org/api/v1/oss_report_selfcheck"


### PR DESCRIPTION
If user enters the download link with wget, an error occurs.

Error Message:
` wget - failed:'LoggingProxy' object has no attribute 'fileno'`